### PR TITLE
Fix stale file lint

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_12" project-jdk-name="12" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ You can install the plugin by opening "Plugins" settings, "Marketplace" - search
 
 - [protolint](https://github.com/yoheimuta/protolint) must be installed.
 - [protobuf-jetbrains-plugin](https://github.com/protostuff/protobuf-jetbrains-plugin) must be installed.
-   - NB: If any warnings from protobuf-jetbrains-plugin exist in a target file, the plugin does not work.
 
 ### Configuration
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.intellij.plugin.protolint'
-version '0.1.1'
+version '0.1.2'
 
 sourceCompatibility = 1.8
 

--- a/src/main/java/com/yoheimuta/intellij/plugin/protolint/ProtolintAnnotator.java
+++ b/src/main/java/com/yoheimuta/intellij/plugin/protolint/ProtolintAnnotator.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public class ProtolintAnnotator extends ExternalAnnotator<PsiFile, List<ProtolintWarning>> {
+public class ProtolintAnnotator extends ExternalAnnotator<Editor, List<ProtolintWarning>> {
     private static final Logger LOGGER = Logger.getInstance(ProtolintAnnotator.class);
 
     public ProtolintAnnotator() {
@@ -24,23 +24,16 @@ public class ProtolintAnnotator extends ExternalAnnotator<PsiFile, List<Protolin
 
     @Nullable
     @Override
-    public PsiFile collectInformation(@NotNull PsiFile file) {
+    public Editor collectInformation(@NotNull PsiFile file, @NotNull Editor editor, boolean hasErrors) {
         LOGGER.debug("Called collectInformation");
-        return file;
+        return editor;
     }
 
     @Nullable
     @Override
-    public PsiFile collectInformation(@NotNull PsiFile file, @NotNull Editor editor, boolean hasErrors) {
-        LOGGER.debug("Called collectInformation2");
-        return super.collectInformation(file, editor, hasErrors);
-    }
-
-    @Nullable
-    @Override
-    public List<ProtolintWarning> doAnnotate(PsiFile file) {
+    public List<ProtolintWarning> doAnnotate(Editor editor) {
         LOGGER.debug("Called doAnnotate");
-        return ProtolintExecutor.execute(file);
+        return ProtolintExecutor.execute(editor);
     }
 
     @Override

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -25,6 +25,11 @@
       | <a href="https://github.com/yoheimuta/protolint/releases">Protolint releases</a>
     ]]></description>
 
+    <change-notes><![CDATA[
+      Version 0.1.2: Lint responsiveness and correctness are significantly improved.
+    ]]>
+    </change-notes>
+
     <idea-version since-build="183"/>
 
     <depends>com.intellij.modules.lang</depends>


### PR DESCRIPTION
ref. [How to trigger ExternalAnnotator running immediately after saving the code change? – IDEs Support (IntelliJ Platform) | JetBrains](https://intellij-support.jetbrains.com/hc/en-us/community/posts/360004284939-How-to-trigger-ExternalAnnotator-running-immediately-after-saving-the-code-change-)